### PR TITLE
remove google service account json dummy

### DIFF
--- a/genarate_confimap_properties_sample.sh
+++ b/genarate_confimap_properties_sample.sh
@@ -62,11 +62,6 @@ GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY=$GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY
 # GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY='-----BEGIN PRIxxx-----\\nxxx==\\n-----END PRIxxx-----'
 # GOOGLE_SERVICE_ACCOUNT_EMAIL=dummy@dummy.iam.gserviceaccount.com
 
-if [ -z "$GOOGLE_SERVICE_ACCOUNT_JSON" ]; then
-  # set dummy key (datasource-api is required)
-  GOOGLE_SERVICE_ACCOUNT_JSON='{"type": "service_account","project_id": "dummy","private_key_id":"dummy","private_key":"dummy","client_email":"dummy@dummy.iam.gserviceaccount.com","client_id": "dummy", "auth_uri":"https://accounts.google.com/o/oauth2/auth", "token_uri":"https://oauth2.googleapis.com/token", "auth_provider_x509_cert_url":"https://www.googleapis.com/oauth2/v1/certs", "client_x509_cert_url":"https://www.googleapis.com/robot/v1/metadata/x509/dummy%40dummy.iam.gserviceaccount.com"}'
-fi
-
 ## Code
 GITHUB_DEFAULT_TOKEN=your-token
 CODE_DATA_KEY=12345678901234567890123456789012


### PR DESCRIPTION
DataSourceAPI側でのGoogle Service Accout Jsonが空の場合の挙動変更に伴い、
configmap設定スクリプトからダミーの値を削除します